### PR TITLE
Fix intel mpi rpm dependencies

### DIFF
--- a/ks/azure/centos65-hpc.ks
+++ b/ks/azure/centos65-hpc.ks
@@ -81,6 +81,8 @@ WALinuxAgent
 msft-rdma-drivers
 kernel-headers
 kernel-devel
+libstdc++.i686
+redhat-lsb
 -hypervkvpd
 -dracut-config-rescue
 

--- a/ks/azure/centos68-hpc.ks
+++ b/ks/azure/centos68-hpc.ks
@@ -81,6 +81,8 @@ WALinuxAgent
 msft-rdma-drivers
 kernel-headers
 kernel-devel
+libstdc++.i686
+redhat-lsb
 -hypervkvpd
 -dracut-config-rescue
 

--- a/ks/azure/centos71-hpc.ks
+++ b/ks/azure/centos71-hpc.ks
@@ -80,6 +80,8 @@ dapl
 libibverbs
 kernel-headers
 kernel-devel
+libstdc++.i686
+redhat-lsb
 -hypervkvpd
 -dracut-config-rescue
 

--- a/ks/azure/centos73-hpc.ks
+++ b/ks/azure/centos73-hpc.ks
@@ -81,6 +81,8 @@ dapl
 libibverbs
 kernel-headers
 kernel-devel
+libstdc++.i686
+redhat-lsb
 -hypervkvpd
 -dracut-config-rescue
 

--- a/ks/azure/centos74-hpc.ks
+++ b/ks/azure/centos74-hpc.ks
@@ -81,6 +81,8 @@ dapl
 libibverbs
 kernel-headers
 kernel-devel
+libstdc++.i686
+redhat-lsb
 -hypervkvpd
 -dracut-config-rescue
 


### PR DESCRIPTION
Current HPC images have issues with their yum dependencies:
```
** Found 9 pre-existing rpmdb problem(s), 'yum check' output follows:
intel-comp-l-all-vars-223-16.0.3-223.noarch has missing requires of lsb >= ('0', '3.0', None)
intel-comp-l-all-vars-223-16.0.3-223.noarch has missing requires of /usr/lib/libstdc++.so.6
intel-compxe-pset-2016.3-068.noarch has missing requires of lsb >= ('0', '3.0', None)
intel-mpi-rt-psxe-068-5.1.3-068.x86_64 has missing requires of lsb >= ('0', '3.0', None)
intel-mpi-rt-psxe-068-5.1.3-068.x86_64 has missing requires of /usr/lib/libstdc++.so.6
intel-psxe-common-2016.3-068.noarch has missing requires of lsb >= ('0', '3.0', None)
intel-psxe-common-2016.3-068.noarch has missing requires of /usr/lib/libstdc++.so.6
intel-psxe-doc-2016.3-068.noarch has missing requires of lsb >= ('0', '3.0', None)
intel-psxe-doc-2016.3-068.noarch has missing requires of /usr/lib/libstdc++.so.6
```

While I would wish intel fixes that in their installer or in their rpms this seems to be the easiest way :)

Greetings
Klaas