### PR TITLE
Update MPI versions

### DIFF
--- a/ks/azure/centos76-hpc-sriov.ks
+++ b/ks/azure/centos76-hpc-sriov.ks
@@ -228,6 +228,7 @@ cd && rm -rf /tmp/mlnxofed
 
 # Configure WALinuxAgent
 sed -i -e 's/# OS.EnableRDMA=y/OS.EnableRDMA=y/g' /etc/waagent.conf
+sed -i -e 's/CGroups.EnforceLimits=n/CGroups.EnforceLimits=y/g' /etc/waagent.conf
 systemctl enable waagent
 
 # Install gcc 8.2
@@ -283,18 +284,18 @@ INSTALL_PREFIX=/opt
 mkdir -p /tmp/mpi
 cd /tmp/mpi
 
-# MVAPICH2 2.3
-wget http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.tar.gz
-tar -xvf mvapich2-2.3.tar.gz
-cd mvapich2-2.3
-./configure --prefix=${INSTALL_PREFIX}/mvapich2-2.3 --enable-g=none --enable-fast=yes && make -j 8 && make install
+# MVAPICH2 2.3.1
+wget http://mvapich.cse.ohio-state.edu/download/mvapich/mv2/mvapich2-2.3.1.tar.gz
+tar -xvf mvapich2-2.3.1.tar.gz
+cd mvapich2-2.3.1
+./configure --prefix=${INSTALL_PREFIX}/mvapich2-2.3.1 --enable-g=none --enable-fast=yes && make -j 8 && make install
 cd ..
 
-# UCX 1.5.0
-wget https://github.com/openucx/ucx/releases/download/v1.5.0/ucx-1.5.0.tar.gz
-tar -xvf ucx-1.5.0.tar.gz 
-cd ucx-1.5.0
-./contrib/configure-release --prefix=${INSTALL_PREFIX}/ucx-1.5.0 && make -j 8 && make install
+# UCX 1.5.1
+wget https://github.com/openucx/ucx/releases/download/v1.5.1/ucx-1.5.1.tar.gz
+tar -xvf ucx-1.5.1.tar.gz
+cd ucx-1.5.1
+./contrib/configure-release --prefix=${INSTALL_PREFIX}/ucx-1.5.1 && make -j 8 && make install
 cd ..
 
 # HPC-X v2.3.0
@@ -306,26 +307,26 @@ HCOLL_PATH=${HPCX_PATH}/hcoll
 rm -rf hpcx-v2.3.0-gcc-MLNX_OFED_LINUX-4.5-1.0.1.0-redhat7.6-x86_64.tbz
 cd /tmp/mpi
 
-# OpenMPI 4.0.0
-wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.0.tar.gz
-tar -xvf openmpi-4.0.0.tar.gz
-cd openmpi-4.0.0
-./configure --prefix=${INSTALL_PREFIX}/openmpi-4.0.0 --with-ucx=${INSTALL_PREFIX}/ucx-1.5.0 --enable-mpirun-prefix-by-default && make -j 8 && make install
+# OpenMPI 4.0.1
+wget https://download.open-mpi.org/release/open-mpi/v4.0/openmpi-4.0.1.tar.gz
+tar -xvf openmpi-4.0.1.tar.gz
+cd openmpi-4.0.1
+./configure --prefix=${INSTALL_PREFIX}/openmpi-4.0.1 --with-ucx=${INSTALL_PREFIX}/ucx-1.5.1 --enable-mpirun-prefix-by-default && make -j 8 && make install
 cd ..
 
 # MPICH 3.3
 wget http://www.mpich.org/static/downloads/3.3/mpich-3.3.tar.gz
 tar -xvf mpich-3.3.tar.gz
 cd mpich-3.3
-./configure --prefix=${INSTALL_PREFIX}/mpich-3.3 --with-ucx=${INSTALL_PREFIX}/ucx-1.5.0 --with-hcoll=${HCOLL_PATH} --enable-g=none --enable-fast=yes --with-device=ch4:ucx   && make -j 8 && make install 
+./configure --prefix=${INSTALL_PREFIX}/mpich-3.3 --with-ucx=${INSTALL_PREFIX}/ucx-1.5.1 --with-hcoll=${HCOLL_PATH} --enable-g=none --enable-fast=yes --with-device=ch4:ucx   && make -j 8 && make install 
 cd ..
 
-# Intel MPI 2019 (update 2)
+# Intel MPI 2019 (update 3)
 CFG="IntelMPI-v2019.x-silent.cfg"
-wget http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15040/l_mpi_2019.2.187.tgz
+wget http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/15260/l_mpi_2019.3.199.tgz
 wget https://raw.githubusercontent.com/szarkos/AzureBuildCentOS/master/config/azure/${CFG}
-tar -xvf l_mpi_2019.2.187.tgz
-cd l_mpi_2019.2.187
+tar -xvf l_mpi_2019.3.199.tgz
+cd l_mpi_2019.3.199
 ./install.sh --silent /tmp/mpi/${CFG}
 cd ..
 
@@ -370,37 +371,54 @@ setenv          MPI_HOME        /opt/mpich-3.3
 EOF
 
 # MVAPICH2
-cat << EOF >> /usr/share/Modules/modulefiles/mpi/mvapich2-2.3
+cat << EOF >> /usr/share/Modules/modulefiles/mpi/mvapich2-2.3.1
 #%Module 1.0
 #
 #  MVAPICH2 2.3
 #
 conflict        mpi
-prepend-path    PATH            /opt/mvapich2-2.3/bin
-prepend-path    LD_LIBRARY_PATH /opt/mvapich2-2.3/lib
-prepend-path    MANPATH         /opt/mvapich2-2.3/share/man
-setenv          MPI_BIN         /opt/mvapich2-2.3/bin
-setenv          MPI_INCLUDE     /opt/mvapich2-2.3/include
-setenv          MPI_LIB         /opt/mvapich2-2.3/lib
-setenv          MPI_MAN         /opt/mvapich2-2.3/share/man
-setenv          MPI_HOME        /opt/mvapich2-2.3
+prepend-path    PATH            /opt/mvapich2-2.3.1/bin
+prepend-path    LD_LIBRARY_PATH /opt/mvapich2-2.3.1/lib
+prepend-path    MANPATH         /opt/mvapich2-2.3.1/share/man
+setenv          MPI_BIN         /opt/mvapich2-2.3.1/bin
+setenv          MPI_INCLUDE     /opt/mvapich2-2.3.1/include
+setenv          MPI_LIB         /opt/mvapich2-2.3.1/lib
+setenv          MPI_MAN         /opt/mvapich2-2.3.1/share/man
+setenv          MPI_HOME        /opt/mvapich2-2.3.1
 EOF
 
 # OpenMPI
-cat << EOF >> /usr/share/Modules/modulefiles/mpi/openmpi-4.0.0
+cat << EOF >> /usr/share/Modules/modulefiles/mpi/openmpi-4.0.1
 #%Module 1.0
 #
-#  OpenMPI 4.0.0
+#  OpenMPI 4.0.1
 #
 conflict        mpi
-prepend-path    PATH            /opt/openmpi-4.0.0/bin
-prepend-path    LD_LIBRARY_PATH /opt/openmpi-4.0.0/lib
-prepend-path    MANPATH         /opt/openmpi-4.0.0/share/man
-setenv          MPI_BIN         /opt/openmpi-4.0.0/bin
-setenv          MPI_INCLUDE     /opt/openmpi-4.0.0/include
-setenv          MPI_LIB         /opt/openmpi-4.0.0/lib
-setenv          MPI_MAN         /opt/openmpi-4.0.0/share/man
-setenv          MPI_HOME        /opt/openmpi-4.0.0
+prepend-path    PATH            /opt/openmpi-4.0.1/bin
+prepend-path    LD_LIBRARY_PATH /opt/openmpi-4.0.1/lib
+prepend-path    MANPATH         /opt/openmpi-4.0.1/share/man
+setenv          MPI_BIN         /opt/openmpi-4.0.1/bin
+setenv          MPI_INCLUDE     /opt/openmpi-4.0.1/include
+setenv          MPI_LIB         /opt/openmpi-4.0.1/lib
+setenv          MPI_MAN         /opt/openmpi-4.0.1/share/man
+setenv          MPI_HOME        /opt/openmpi-4.0.1
+EOF
+
+#IntelMPI-v2019
+cat << EOF >> /usr/share/Modules/modulefiles/mpi/impi-2019.3.199
+#%Module 1.0
+#
+#  Intel MPI 2019.3.199
+#
+conflict        mpi
+prepend-path    PATH            /opt/intel/impi/2019.3.199/intel64/bin
+prepend-path    LD_LIBRARY_PATH /opt/intel/impi/2019.3.199/intel64/lib
+prepend-path    MANPATH         /opt/intel/impi/2019.3.199/man
+setenv          MPI_BIN         /opt/intel/impi/2019.3.199/intel64/bin
+setenv          MPI_INCLUDE     /opt/intel/impi/2019.3.199/intel64/include
+setenv          MPI_LIB         /opt/intel/impi/2019.3.199/intel64/lib
+setenv          MPI_MAN         /opt/intel/impi/2019.3.199/man
+setenv          MPI_HOME        /opt/intel/impi/2019.3.199/intel64
 EOF
 
 


### PR DESCRIPTION
 - MVAPICH2 2.3.1
 - UCX 1.5.1
 - OpenMPI 4.0.1
 - Enable waagent CPU/Memory limits