### PR TITLE
remove hyperv telemetry reporter configuration

### DIFF
--- a/ks/azure/centos76-CI.ks
+++ b/ks/azure/centos76-CI.ks
@@ -205,16 +205,6 @@ cat > /etc/cloud/cloud.cfg.d/91-azure_datasource.cfg <<EOF
 datasource_list: [ Azure ]
 EOF
 
-# Enable the KVP telemetry
-cat > /etc/cloud/cloud.cfg.d/10-azure-kvp.cfg <<EOF
-# This configuration file is used to enable logging to Hyper-V kvp
-reporting:
-  logging:
-    type: log
-  telemetry:
-    type: hyperv
-EOF
-
 if [[ -f /mnt/resource/swapfile ]]; then
     echo removing swapfile
     swapoff /mnt/resource/swapfile


### PR DESCRIPTION
Pulling the hyperv telemetry configuration because cloudinit 18.2 package does not have the hyper-v telemetry reporter. 