### PR TITLE
Fixes for CentOS 8.0 KS

### DIFF
--- a/ks/azure/centos80.ks
+++ b/ks/azure/centos80.ks
@@ -113,9 +113,6 @@ centos-release
 cloud-utils-growpart
 gdisk
 
-# add insight-clients
-insights-client
-
 %end
 
 %post --log=/var/log/anaconda/post-install.log --erroronfail


### PR DESCRIPTION
 - Remove insights-client
 - Enable BIOS and UEFI boot in a single image