### PR TITLE
Update centos80.ks to use the newer pkg groups

### DIFF
--- a/ks/azure/centos80.ks
+++ b/ks/azure/centos80.ks
@@ -72,8 +72,8 @@ sgdisk --typecode=15:EF00 /dev/sda
 
 %packages
 WALinuxAgent
-@base
-@core
+@^minimal-environment
+@standard
 #@container-tools
 chrony
 sudo


### PR DESCRIPTION
Per our email discussion about anaconda moving to the newer package group names