### PR TITLE
Update CentOS 7.6, 7.7 HPC images

### DIFF
--- a/ks/azure/centos76-hpc-sriov.ks
+++ b/ks/azure/centos76-hpc-sriov.ks
@@ -218,7 +218,7 @@ SUBSYSTEM=="net", DRIVERS=="hv_pci", ACTION=="add", ENV{NM_UNMANAGED}="1"
 EOF
 
 cd /tmp
-CENTOS_HPC_VERSION="centos-7.6-hpc-20191107"
+CENTOS_HPC_VERSION="centos-7.6-hpc-20200306"
 wget https://github.com/Azure/azhpc-images/archive/${CENTOS_HPC_VERSION}.tar.gz
 tar -xvf ${CENTOS_HPC_VERSION}.tar.gz
 cd azhpc-images-${CENTOS_HPC_VERSION}/centos/centos-7.6-hpc

--- a/ks/azure/centos77-hpc-sriov.ks
+++ b/ks/azure/centos77-hpc-sriov.ks
@@ -218,7 +218,7 @@ SUBSYSTEM=="net", DRIVERS=="hv_pci", ACTION=="add", ENV{NM_UNMANAGED}="1"
 EOF
 
 cd /tmp
-CENTOS_HPC_VERSION="centos-7.7-hpc-20191107"
+CENTOS_HPC_VERSION="centos-7.7-hpc-20200306"
 wget https://github.com/Azure/azhpc-images/archive/${CENTOS_HPC_VERSION}.tar.gz
 tar -xvf ${CENTOS_HPC_VERSION}.tar.gz
 cd azhpc-images-${CENTOS_HPC_VERSION}/centos/centos-7.7-hpc


### PR DESCRIPTION
- Mellanox OFED 5.0
- Pre-configured IPoIB (IP-over-InfiniBand)
- Popular InfiniBand based MPI Libraries
  - HPC-X 2.6.0
  - IntelMPI 2018.4, 2019.6
  - MVAPICH2 2.3.3
  - MVAPICH2X 2.3.rc3
  - OpenMPI 4.0.3
- Communication Runtimes
  - Libfabric
  - OpenUCX
- Optimized libraries
  - AMD Blis 2.0
  - AMD FFTW 2.0
  - AMD Flame 2.0
  - Intel MKL 2019.5.281
- GCC 9.2.0