### PR TITLE
Updating Azhpc-Image Release for CentOS 8.1, 7.7 and 7.6

### DIFF
--- a/ks/azure/centos76-hpc-sriov.ks
+++ b/ks/azure/centos76-hpc-sriov.ks
@@ -237,7 +237,7 @@ SUBSYSTEM=="net", DRIVERS=="hv_pci", ACTION=="add", ENV{NM_UNMANAGED}="1"
 EOF
 
 cd /tmp
-CENTOS_HPC_VERSION="centos-7.6-hpc-20200629"
+CENTOS_HPC_VERSION="centos-hpc-20200814"
 wget https://github.com/Azure/azhpc-images/archive/${CENTOS_HPC_VERSION}.tar.gz
 tar -xvf ${CENTOS_HPC_VERSION}.tar.gz
 cd azhpc-images-${CENTOS_HPC_VERSION}/centos/centos-7.x/centos-7.6-hpc

--- a/ks/azure/centos77-hpc-sriov.ks
+++ b/ks/azure/centos77-hpc-sriov.ks
@@ -237,7 +237,7 @@ SUBSYSTEM=="net", DRIVERS=="hv_pci", ACTION=="add", ENV{NM_UNMANAGED}="1"
 EOF
 
 cd /tmp
-CENTOS_HPC_VERSION="centos-7.7-hpc-20200417"
+CENTOS_HPC_VERSION="centos-hpc-20200814"
 wget https://github.com/Azure/azhpc-images/archive/${CENTOS_HPC_VERSION}.tar.gz
 tar -xvf ${CENTOS_HPC_VERSION}.tar.gz
 cd azhpc-images-${CENTOS_HPC_VERSION}/centos/centos-7.x/centos-7.7-hpc

--- a/ks/azure/centos81-hpc.ks
+++ b/ks/azure/centos81-hpc.ks
@@ -243,7 +243,7 @@ EOF
 
 
 cd /tmp
-CENTOS_HPC_VERSION="centos-8.1-hpc-20200409"
+CENTOS_HPC_VERSION="centos-hpc-20200814"
 wget https://github.com/Azure/azhpc-images/archive/${CENTOS_HPC_VERSION}.tar.gz
 tar -xvf ${CENTOS_HPC_VERSION}.tar.gz
 cd azhpc-images-${CENTOS_HPC_VERSION}/centos/centos-8.x/centos-8.1-hpc


### PR DESCRIPTION
Updating Azhpc-Image Release for CentOS 8.1, 7.7 and 7.6,
The new release has following updates,
* Mellanox OFED 5.1-0
* Popular InfiniBand based MPI Libraries
  * HPC-X 2.7.0
  * IntelMPI 2019.8
  * MVAPICH2 2.3.4
  * MVAPICH2X 2.3
  * OpenMPI 4.0.4
* Optimized libraries
  * AMD Blis 2.2
  * AMD FFTW 2.2
  * AMD Flame 2.2