### PR TITLE
Adding Azure HPC Version for CentOS76-hpc-sriov, CentOS77-hpc-sriov, CentOS78-hpc and CentOS81-hpc

### DIFF
--- a/ks/azure/centos76-hpc-sriov.ks
+++ b/ks/azure/centos76-hpc-sriov.ks
@@ -265,6 +265,11 @@ cd azhpc-images-${CENTOS_HPC_VERSION}/centos/centos-7.x/centos-7.6-hpc
 ./install.sh
 cd && rm -rf /tmp/azhpc-images-${CENTOS_HPC_VERSION}
 
+# Add Azure HPC image version
+cat << EOF > /opt/azurehpc/azhpc-version
+${CENTOS_HPC_VERSION}
+EOF
+
 # Enable PTP with chrony for accurate time sync
 echo -e "\nrefclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0\n" >> /etc/chrony.conf
 sed -i 's/makestep.*$/makestep 1.0 -1/g' /etc/chrony.conf

--- a/ks/azure/centos77-hpc-sriov.ks
+++ b/ks/azure/centos77-hpc-sriov.ks
@@ -265,6 +265,11 @@ cd azhpc-images-${CENTOS_HPC_VERSION}/centos/centos-7.x/centos-7.7-hpc
 ./install.sh
 cd && rm -rf /tmp/azhpc-images-${CENTOS_HPC_VERSION}
 
+# Add Azure HPC image version
+cat << EOF > /opt/azurehpc/azhpc-version
+${CENTOS_HPC_VERSION}
+EOF
+
 # Enable PTP with chrony for accurate time sync
 echo -e "\nrefclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0\n" >> /etc/chrony.conf
 sed -i 's/makestep.*$/makestep 1.0 -1/g' /etc/chrony.conf

--- a/ks/azure/centos78-hpc.ks
+++ b/ks/azure/centos78-hpc.ks
@@ -255,6 +255,11 @@ cd azhpc-images-${CENTOS_HPC_VERSION}/centos/centos-7.x/centos-7.8-hpc
 ./install.sh
 cd && rm -rf /tmp/azhpc-images-${CENTOS_HPC_VERSION}
 
+# Add Azure HPC image version
+cat << EOF > /opt/azurehpc/azhpc-version
+${CENTOS_HPC_VERSION}
+EOF
+
 # Enable PTP with chrony for accurate time sync
 echo -e "\nrefclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0\n" >> /etc/chrony.conf
 sed -i 's/makestep.*$/makestep 1.0 -1/g' /etc/chrony.conf

--- a/ks/azure/centos81-hpc.ks
+++ b/ks/azure/centos81-hpc.ks
@@ -250,6 +250,11 @@ cd azhpc-images-${CENTOS_HPC_VERSION}/centos/centos-8.x/centos-8.1-hpc
 ./install.sh
 cd && rm -rf /tmp/azhpc-images-${CENTOS_HPC_VERSION}
 
+# Add Azure HPC image version
+cat << EOF > /opt/azurehpc/azhpc-version
+${CENTOS_HPC_VERSION}
+EOF
+
 # Enable PTP with chrony for accurate time sync
 echo -e "\nrefclock PHC /dev/ptp0 poll 3 dpoll -2 offset 0\n" >> /etc/chrony.conf
 sed -i 's/makestep.*$/makestep 1.0 -1/g' /etc/chrony.conf


### PR DESCRIPTION
Adding Azure HPC Version for 
- CentOS76-hpc-sriov
- CentOS77-hpc-sriov
- CentOS78-hpc
- CentOS81-hpc